### PR TITLE
Migrate to Null safety

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,10 +6,10 @@ repository: https://github.com/adaptant-labs/flutter_windowmanager
 issue_tracker: https://github.com/adaptant-labs/flutter_windowmanager/issues
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
   # Flutter versions prior to 1.10 did not support
   # the flutter.plugin.platforms map.
-  flutter: ">=1.10.0"
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=1.17.0"
 
 dependencies:
   flutter:

--- a/test/flutter_windowmanager_test.dart
+++ b/test/flutter_windowmanager_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_windowmanager/flutter_windowmanager.dart';
 
 void main() {
   const MethodChannel channel = MethodChannel('flutter_windowmanager');
-  final List<MethodCall> log = List<MethodCall>();
+  final List<MethodCall> log = <MethodCall>[];
 
   setUp(() {
     channel.setMockMethodCallHandler((MethodCall methodCall) async {


### PR DESCRIPTION
- upgrade dependecies
 - migrated to null safety
- fixing 'List' is deprecated and shouldn't be used in test file