### PR TITLE
Added support to null safety. Fixes #13.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -24,7 +24,7 @@ class _MyAppState extends State<MyApp> {
             crossAxisAlignment: CrossAxisAlignment.center,
             children: <Widget>[
               Text('Secure Mode: ${_secureMode.toString()}\n'),
-              RaisedButton(
+              ElevatedButton(
                   onPressed: () async {
                     final secureModeToggle = !_secureMode;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/adaptant-labs/flutter_windowmanager
 issue_tracker: https://github.com/adaptant-labs/flutter_windowmanager/issues
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   # Flutter versions prior to 1.10 did not support
   # the flutter.plugin.platforms map.
   flutter: ">=1.10.0"

--- a/test/flutter_windowmanager_test.dart
+++ b/test/flutter_windowmanager_test.dart
@@ -3,12 +3,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_windowmanager/flutter_windowmanager.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   const MethodChannel channel = MethodChannel('flutter_windowmanager');
-  final List<MethodCall> log = List<MethodCall>();
+  final List<MethodCall> log = <MethodCall>[];
 
   setUp(() {
     channel.setMockMethodCallHandler((MethodCall methodCall) async {
       log.add(methodCall);
+      return true;
     });
   });
 


### PR DESCRIPTION
I was using this package in an app I'm just porting to Flutter 2.2.  I'm not used to write plugins nor MethodChannels, but thanks to the unit tests I believe I added support to null safety in this package.

I'd like to propose this fix for evaluation and merge it, if that is useful.