### PR TITLE
flutter embedding v2 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+* Finish flutter embedding v2 migration. #17
+
 ## 0.1.0
 
 * null-safety migration (@ValeteTech, PR#16)

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -7,23 +7,20 @@
             android:name="flutterEmbedding"
             android:value="2"/>
         <activity
-            android:name=".MainActivity"
+            android:name="io.flutter.embedding.android.FlutterActivity"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
-            <!-- This keeps the window background of the activity showing
-                 until Flutter renders its first frame. It can be removed if
-                 there is no splash screen (such as the default splash screen
-                 defined in @style/LaunchTheme). -->
-            <meta-data
-                android:name="io.flutter.app.android.SplashScreenUntilFirstFrame"
-                android:value="true" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <meta-data
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme"
+                />
         </activity>
     </application>
 </manifest>

--- a/example/android/app/src/main/java/io/adaptant/labs/flutter_windowmanager_example/MainActivity.java
+++ b/example/android/app/src/main/java/io/adaptant/labs/flutter_windowmanager_example/MainActivity.java
@@ -1,6 +1,0 @@
-package io.adaptant.labs.flutter_windowmanager_example;
-
-import io.flutter.embedding.android.FlutterActivity;
-
-public class MainActivity extends FlutterActivity {
-}

--- a/example/android/app/src/main/res/values/styles.xml
+++ b/example/android/app/src/main/res/values/styles.xml
@@ -5,4 +5,6 @@
              Flutter draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
     </style>
+    <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
+    </style>
 </resources>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_windowmanager
 description: A Flutter plugin for manipulating Android WindowManager LayoutParams.
-version: 0.1.0
+version: 0.2.0
 homepage: https://github.com/adaptant-labs/flutter_windowmanager
 repository: https://github.com/adaptant-labs/flutter_windowmanager
 issue_tracker: https://github.com/adaptant-labs/flutter_windowmanager/issues


### PR DESCRIPTION
Migrate to flutter embedding v2. fixes  #17

* https://flutter.dev/docs/development/packages-and-plugins/plugin-api-migration
* https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects

It looks like there was an attempt in https://github.com/adaptant-labs/flutter_windowmanager/commit/0a3e2cad3c122e5b12f16d82b3f0c3a97cbeb4d0 but this only touched on the example app, not the plugin. and the only thing related to v2 embedding was the introduction of the `meta-data` in the `AndroidManifest.xml`, nothing else.
