### PR TITLE
add namespace to build gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'io.adaptant.labs.flutter_windowmanager'
     compileSdkVersion 28
 
     defaultConfig {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_windowmanager
 description: A Flutter plugin for manipulating Android WindowManager LayoutParams.
-version: 0.2.0
+version: 0.2.1
 homepage: https://github.com/adaptant-labs/flutter_windowmanager
 repository: https://github.com/adaptant-labs/flutter_windowmanager
 issue_tracker: https://github.com/adaptant-labs/flutter_windowmanager/issues


### PR DESCRIPTION
add namespace     

`namespace 'io.adaptant.labs.flutter_windowmanager'`

to build gradle and up version