### PR TITLE
Update FlutterWindowManagerPlugin.java (Support for Flutter 3.29.0)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ version '1.0'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -15,7 +15,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/android/src/main/java/io/adaptant/labs/flutter_windowmanager/FlutterWindowManagerPlugin.java
+++ b/android/src/main/java/io/adaptant/labs/flutter_windowmanager/FlutterWindowManagerPlugin.java
@@ -14,7 +14,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /** FlutterWindowManagerPlugin */
 public class FlutterWindowManagerPlugin implements MethodCallHandler, FlutterPlugin, ActivityAware {
@@ -28,11 +27,6 @@ public class FlutterWindowManagerPlugin implements MethodCallHandler, FlutterPlu
   }
 
   /** Plugin registration. */
-  @Deprecated
-  public static void registerWith(Registrar registrar) {
-    new FlutterWindowManagerPlugin(registrar.activity()).registerWith(registrar.messenger());
-  }
-
   private void registerWith(BinaryMessenger binaryMessenger) {
     final MethodChannel channel = new MethodChannel(binaryMessenger, "flutter_windowmanager");
     channel.setMethodCallHandler(this);


### PR DESCRIPTION
Support for Flutter 3.29.0
Removed import io.flutter.plugin.common.PluginRegistry.Registrar and deprecated plugin registration code